### PR TITLE
add nfc.cards to vendors list

### DIFF
--- a/index.html
+++ b/index.html
@@ -381,8 +381,10 @@
                                  <p>
                                     <ul>
                                        <li><a href="https://marpple.shop/kr/yanabu/products/13356281">Yanabu Bolt Card - Korea</a></li>
-                                       <li><a href="https://lasereyes.cards/buy-now/">Laser Eyes Cards</a></li>                                       <li><a href="https://shop.identiv.com/collections/nfc-tags/products/printed-nxp-ntag-424-dna-tag-5-pack">Identiv.com</a></li>
+                                       <li><a href="https://lasereyes.cards/buy-now/">Laser Eyes Cards</a></li>
+                                       <li><a href="https://shop.identiv.com/collections/nfc-tags/products/printed-nxp-ntag-424-dna-tag-5-pack">Identiv.com</a></li>
                                        <li><a href="https://zipnfc.com/nfc-pvc-card-credit-card-size-ntag424-dna.html">ZipNFC.com</a></li>
+                                       <li><a href="https://nfc.cards/en/white-cards/46-nfc-card-ntag424-dna.html">NFC.CARDS</a></li>
                                        <li><a href="https://www.coincorner.com/BuyTheBoltCard">CoinCorner.com</a></li>
                                        <li><a href="https://plebtag.com/">PlebTag</a></li>
                                        <li><a href="https://www.bitcoin-ring.com/">Bolt Ring</a></li>


### PR DESCRIPTION
This commit adds the website nfc.card to the list of vendors.

I ordered a batch there myself, it arrived quickly, well packaged and works with the Boltcard NCF Programmer app.

I think it would be nice to have it mentioned  on the website because none of the options already mentioned was really cost effective for me (living in France), and after a bit of searching I finally found this vendor. It's located in Dijon, France, which makes it a nice vendor for lots of European countries.